### PR TITLE
Fix deep sleep: RTC channel regression + missing recharge priming

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -57,7 +57,7 @@ static void delay_cycles(volatile uint32_t n)
 // because the Cortex-M3 requires an NVIC-enabled interrupt to wake.
 void AON_RTC_Handler(void)
 {
-    AONRTCEventClear(AON_RTC_CH0);
+    AONRTCEventClear(AON_RTC_CH1);
 }
 
 // Enter deep sleep with RTC-timed wakeup.
@@ -80,16 +80,19 @@ static void enter_sleep(uint32_t seconds)
     oepl_rf_shutdown();
 
     // Configure RTC wakeup (16.16 fixed-point format: seconds in upper 16 bits)
+    // Uses CH1, not CH0: CH0's compare event flag never sets on this chip
+    // (confirmed by hardware testing — see commit 1397067). CH1 works.
     AONRTCEnable();
     uint32_t now = AONRTCCurrentCompareValueGet();
     uint32_t target = now + (seconds << 16);
-    AONRTCCompareValueSet(AON_RTC_CH0, target);
-    AONRTCChannelEnable(AON_RTC_CH0);
-    AONRTCEventClear(AON_RTC_CH0);
+    AONRTCModeCh1Set(AON_RTC_MODE_CH1_COMPARE);
+    AONRTCCompareValueSet(AON_RTC_CH1, target);
+    AONRTCChannelEnable(AON_RTC_CH1);
+    AONRTCEventClear(AON_RTC_CH1);
 
-    // Configure combined event to include CH0 — drives INT_AON_RTC_COMB.
-    // Without this, CH0 compare match never reaches NVIC, WFI never wakes.
-    AONRTCCombinedEventConfig(AON_RTC_CH0);
+    // Configure combined event to include CH1 — drives INT_AON_RTC_COMB.
+    // Without this, CH1 compare match never reaches NVIC, WFI never wakes.
+    AONRTCCombinedEventConfig(AON_RTC_CH1);
 
     // Clear stale NVIC pending + enable RTC NVIC interrupt
     IntPendClear(INT_AON_RTC_COMB);
@@ -99,8 +102,8 @@ static void enter_sleep(uint32_t seconds)
     warmboot_magic_a = WARMBOOT_MAGIC_A;
     warmboot_magic_b = WARMBOOT_MAGIC_B;
 
-    // Route RTC CH0 to MCU wakeup event (for PRCM standby wakeup)
-    AONEventMcuWakeUpSet(AON_EVENT_MCU_WU0, AON_EVENT_RTC_CH0);
+    // Route RTC CH1 to MCU wakeup event (for PRCM standby wakeup)
+    AONEventMcuWakeUpSet(AON_EVENT_MCU_WU0, AON_EVENT_RTC_CH1);
 
     // --- Standby configuration ---
     // SERIAL domain off crashes consistently (tests 6-8). Skip it.
@@ -108,6 +111,15 @@ static void enter_sleep(uint32_t seconds)
 
     // Power off PERIPH domain (GPIO, Timer, UDMA)
     PRCMPowerDomainOff(PRCM_DOMAIN_PERIPH);
+
+    // Prime the adaptive recharge controller before power-down (driverlib
+    // docs: "shall be called just before entering Power Down"). Without
+    // this, the recharge controller is never configured before the first
+    // PRCMDeepSleep() call, which was reliably hanging inside TI's ROM
+    // standby-entry sequence (confirmed via JLink: PC stuck polling an
+    // AON_RTC-region register, reproducible across multiple sleep cycles).
+    // Paired with SysCtrlAdjustRechargeAfterPowerDown() on wake.
+    SysCtrlSetRechargeBeforePowerDown(XOSC_IN_HIGH_POWER_MODE);
 
     // Freeze IO for warm boot detection
     AONIOCFreezeEnable();
@@ -125,7 +137,7 @@ static void enter_sleep(uint32_t seconds)
     warmboot_magic_b = 0;
     IntDisable(INT_AON_RTC_COMB);
     IntPendClear(INT_AON_RTC_COMB);
-    AONRTCEventClear(AON_RTC_CH0);
+    AONRTCEventClear(AON_RTC_CH1);
 
     // Re-enable PERIPH domain for GPIO
     HWREG(PRCM_BASE + PRCM_O_PDCTL0PERIPH) = 1;


### PR DESCRIPTION
Two independent bugs were both causing the tag to check in a couple of times and then go permanently silent — each severe enough on its own to fully explain that symptom.

### 1. AON_RTC channel regression

`enter_sleep()` configured wakeup on `AON_RTC_CH0`, for both the WFI/NVIC path and the PRCM standby wakeup event. An earlier commit (1397067) had already found via hardware testing that CH0's compare event flag never sets on this chip, and moved wakeup to CH1 — but that fix was silently lost when `enter_sleep()` was later rebuilt around `PRCMDeepSleep()` and reverted back to CH0. Since `AONEventMcuWakeUpSet()`'s standby wakeup source depends on the same broken compare event, the tag would enter deep sleep and never return.

**Fix:** switch back to CH1 throughout.

### 2. Missing recharge-controller priming

Driverlib's own docs for `SysCtrlSetRechargeBeforePowerDown()` are explicit: *"shall be called just before entering Power Down."* `enter_sleep()` never called it — only the after-wake counterpart, and only conditionally on warm boot. Without it, the adaptive recharge controller is never configured before the first `PRCMDeepSleep()` call.

Confirmed via JLink: the CPU could get stuck inside TI's ROM standby-entry sequence, PC parked polling an AON_RTC-region register that never resolves.

**Fix:** call `SysCtrlSetRechargeBeforePowerDown()` before every sleep entry, paired with the existing after-wake call.

### Note

`main.c` also currently calls `SysCtrlAdjustRechargeAfterPowerDown()` with a `0` argument, which doesn't match the SDK headers on this toolchain (expects `void`) and won't compile as-is. That's a pre-existing, unrelated issue tied to a toolchain/SDK version mismatch and is intentionally left out of this PR — tracked separately.