### PR TITLE
Speed up and fix reliability of block transfers

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -192,11 +192,13 @@ bool download_block(uint8_t block_id, struct AvailDataInfo *info,
     memset(parts_rcvd, 0, sizeof(parts_rcvd));
     memset(buf, 0x00, BLOCK_XFER_BUFFER_SIZE);
 
-    // Attempt count and backoff modeled on the official OEPL ZBS243 tag
-    // firmware's BLOCK_TRANSFER_ATTEMPTS=5 — spacing between attempts now
-    // comes from the AP's own pleaseWaitMs (handled inside
-    // oepl_radio_request_block), not a fixed extra delay here.
-    uint8_t zero_count = 0;  // consecutive attempts with 0 parts received
+    // Attempt count modeled on the official OEPL ZBS243 tag firmware's
+    // BLOCK_TRANSFER_ATTEMPTS=5 — spacing between attempts comes from the
+    // AP's own pleaseWaitMs (handled inside oepl_radio_request_block), not
+    // a fixed extra delay here. No early-bail-on-zero-parts heuristic
+    // (official doesn't have one either): with only 5 attempts at ~1s
+    // each, a couple of unlucky zero-response tries on a busy channel
+    // shouldn't cost the block its remaining budget.
     for (uint8_t attempt = 0; attempt < 5; attempt++) {
         if (attempt > 0) rtt_puts("R");
         uint8_t got = oepl_radio_request_block(block_id, info->dataVer, info->dataType,
@@ -212,16 +214,6 @@ bool download_block(uint8_t block_id, struct AvailDataInfo *info,
             rtt_puts("~");
             *out_size = BLOCK_XFER_BUFFER_SIZE;
             return true;
-        }
-        // If AP isn't responding at all (0 parts, twice), give up early
-        if (got == 0) {
-            zero_count++;
-            if (zero_count >= 2) {
-                rtt_puts("X");
-                break;
-            }
-        } else {
-            zero_count = 0;
         }
     }
     rtt_puts("!");

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -192,12 +192,13 @@ bool download_block(uint8_t block_id, struct AvailDataInfo *info,
     memset(parts_rcvd, 0, sizeof(parts_rcvd));
     memset(buf, 0x00, BLOCK_XFER_BUFFER_SIZE);
 
+    // Attempt count and backoff modeled on the official OEPL ZBS243 tag
+    // firmware's BLOCK_TRANSFER_ATTEMPTS=5 — spacing between attempts now
+    // comes from the AP's own pleaseWaitMs (handled inside
+    // oepl_radio_request_block), not a fixed extra delay here.
     uint8_t zero_count = 0;  // consecutive attempts with 0 parts received
-    for (uint8_t attempt = 0; attempt < 15; attempt++) {
-        if (attempt > 0) {
-            rtt_puts("R");
-            oepl_hw_delay_ms(500);
-        }
+    for (uint8_t attempt = 0; attempt < 5; attempt++) {
+        if (attempt > 0) rtt_puts("R");
         uint8_t got = oepl_radio_request_block(block_id, info->dataVer, info->dataType,
                                                 buf, parts_rcvd);
         if (got >= BLOCK_MAX_PARTS) {
@@ -205,16 +206,17 @@ bool download_block(uint8_t block_id, struct AvailDataInfo *info,
             *out_size = BLOCK_XFER_BUFFER_SIZE;
             return true;
         }
-        // Accept 41/42 only after 8 attempts
-        if (got >= BLOCK_MAX_PARTS - 1 && attempt >= 7) {
+        // Accept 41/42 once only one attempt remains rather than burning
+        // the whole budget chasing a single chronically-lost part.
+        if (got >= BLOCK_MAX_PARTS - 1 && attempt >= 3) {
             rtt_puts("~");
             *out_size = BLOCK_XFER_BUFFER_SIZE;
             return true;
         }
-        // If AP isn't responding at all (0 parts, 3 times), give up early
+        // If AP isn't responding at all (0 parts, twice), give up early
         if (got == 0) {
             zero_count++;
-            if (zero_count >= 3) {
+            if (zero_count >= 2) {
                 rtt_puts("X");
                 break;
             }

--- a/firmware/oepl_hw_abstraction_cc2630.c
+++ b/firmware/oepl_hw_abstraction_cc2630.c
@@ -14,6 +14,7 @@
 #include "hw_memmap.h"
 #include "hw_types.h"  // for HWREG
 #include "aon_batmon.h"
+#include "aon_rtc.h"
 
 // Pin assignments — from STOCK FIRMWARE binary analysis (v29)
 // SPI pins: MOSI/MISO swapped vs OEPL HAL! Stock has mosiPin=9, misoPin=8
@@ -206,7 +207,13 @@ void oepl_hw_delay_us(uint32_t us)
 
 uint32_t oepl_hw_get_time_ms(void)
 {
-    return 0;  // Not implemented — not needed for display driver
+    // AON_RTC free-runs off the always-on domain; enabling it is a single
+    // idempotent register bit, so no separate one-time init is needed.
+    AONRTCEnable();
+    uint32_t raw = AONRTCCurrentCompareValueGet();  // <16.16>: seconds.fraction
+    uint32_t sec = raw >> 16;
+    uint32_t frac_ms = (raw & 0xFFFF) * 1000UL >> 16;
+    return sec * 1000UL + frac_ms;
 }
 
 bool oepl_hw_get_temperature(int8_t* temp_degc)

--- a/firmware/oepl_radio_cc2630.c
+++ b/firmware/oepl_radio_cc2630.c
@@ -321,8 +321,9 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
     rtt_puts("BRQ b=");
     rtt_put_hex8(block_id);
 
-    // Single long RX session: covers ack + wait + all parts (15s)
-    rf_status_t rc = oepl_rf_rx_start(radio_st.current_ieee_ch, 15000000);
+    // Hardware end-trigger is just a backstop; the real deadline is tracked
+    // below against the AON RTC ms clock (see BLOCK_ACK_WAIT_MS et al).
+    rf_status_t rc = oepl_rf_rx_start(radio_st.current_ieee_ch, BLOCK_RX_HW_TIMEOUT_US);
     if (rc != RF_OK) { rtt_puts(" RXfail\r\n"); return total_parts; }
 
     // TX block request
@@ -334,19 +335,22 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
     }
     rtt_puts(" TX+\r\n");
 
-    // Receive ack + parts in one continuous RX session
+    // Receive ack + parts in one continuous RX session. Deadline starts as
+    // a short ack wait; once the ack (or a part, if it beats the ack)
+    // arrives, it's pushed out to cover the AP's requested pleaseWaitMs
+    // plus a short part-burst window — mirrors the official tag firmware's
+    // ack + pleaseWaitMs + blockRxLoop(295ms) sequence, without needing to
+    // tear down and restart the RX command between phases.
     bool got_ack = false;
     uint8_t other_pkts = 0;
+    uint32_t deadline = oepl_hw_get_time_ms() + BLOCK_ACK_WAIT_MS;
 
-    for (volatile uint32_t w = 0; w < 30000000; w++) {
+    while ((int32_t)(oepl_hw_get_time_ms() - deadline) < 0) {
         uint8_t pkt_len;
         int8_t rssi;
         uint8_t *pkt = oepl_rf_rx_get(&pkt_len, &rssi);
         if (!pkt) {
-            // Periodically check if RX is still active
-            if ((w & 0xFFFFF) == 0 && w > 0) {
-                if (oepl_rf_rx_status() != ACTIVE) break;
-            }
+            if (oepl_rf_rx_status() != ACTIVE) break;
             continue;
         }
 
@@ -355,13 +359,20 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
         if (hsz > 0 && pkt_len > hsz) {
             uint8_t pkt_type = pkt[hsz];
 
-            if (pkt_type == PKT_BLOCK_REQUEST_ACK && pkt_len >= hsz + 1 + 3) {
+            if (pkt_type == PKT_BLOCK_REQUEST_ACK &&
+                pkt_len >= hsz + 1 + sizeof(struct BlockRequestAck)) {
                 struct BlockRequestAck *ack = (struct BlockRequestAck *)&pkt[hsz + 1];
-                got_ack = true;
-                rtt_puts("ACK w=");
-                rtt_put_hex8((ack->pleaseWaitMs >> 8) & 0xFF);
-                rtt_put_hex8(ack->pleaseWaitMs & 0xFF);
-                rtt_puts("\r\n");
+                if (!got_ack && check_crc(ack, sizeof(struct BlockRequestAck))) {
+                    got_ack = true;
+                    rtt_puts("ACK w=");
+                    rtt_put_hex8((ack->pleaseWaitMs >> 8) & 0xFF);
+                    rtt_put_hex8(ack->pleaseWaitMs & 0xFF);
+                    rtt_puts("\r\n");
+
+                    uint16_t wait_ms = ack->pleaseWaitMs;
+                    if (wait_ms > BLOCK_MAX_WAIT_MS) wait_ms = BLOCK_MAX_WAIT_MS;
+                    deadline = oepl_hw_get_time_ms() + wait_ms + BLOCK_PART_WINDOW_MS;
+                }
             } else if (pkt_type == PKT_BLOCK_PART &&
                        pkt_len >= hsz + 1 + sizeof(struct BlockPart)) {
                 struct BlockPart *bp = (struct BlockPart *)&pkt[hsz + 1];
@@ -378,6 +389,10 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
                         parts_rcvd[byte_idx] |= (1 << bit_idx);
                         total_parts++;
                     }
+                    // Data is flowing (possibly before we ever saw the ack)
+                    // — keep the window open long enough for the rest of it.
+                    uint32_t part_deadline = oepl_hw_get_time_ms() + BLOCK_PART_WINDOW_MS;
+                    if ((int32_t)(part_deadline - deadline) > 0) deadline = part_deadline;
                 }
             } else {
                 other_pkts++;

--- a/firmware/oepl_radio_cc2630.c
+++ b/firmware/oepl_radio_cc2630.c
@@ -345,14 +345,17 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
     uint8_t other_pkts = 0;
     uint32_t deadline = oepl_hw_get_time_ms() + BLOCK_ACK_WAIT_MS;
 
+    // Exit is governed by the ms deadline (and total_parts completion)
+    // below, not oepl_rf_rx_status(): polling that every iteration (rather
+    // than the old code's sparse ~1M-iteration throttle) can catch a brief
+    // non-ACTIVE blip in the TX-to-RX turnaround and bail before any part
+    // has a chance to arrive. The RX hardware timeout is a generous backstop
+    // regardless, so there's nothing to gain from checking status here.
     while ((int32_t)(oepl_hw_get_time_ms() - deadline) < 0) {
         uint8_t pkt_len;
         int8_t rssi;
         uint8_t *pkt = oepl_rf_rx_get(&pkt_len, &rssi);
-        if (!pkt) {
-            if (oepl_rf_rx_status() != ACTIVE) break;
-            continue;
-        }
+        if (!pkt) continue;
 
         // Parse header size from frame control
         uint8_t hsz = mac_hdr_size(pkt, pkt_len);
@@ -362,7 +365,10 @@ uint8_t oepl_radio_request_block(uint8_t block_id, uint64_t data_ver, uint8_t da
             if (pkt_type == PKT_BLOCK_REQUEST_ACK &&
                 pkt_len >= hsz + 1 + sizeof(struct BlockRequestAck)) {
                 struct BlockRequestAck *ack = (struct BlockRequestAck *)&pkt[hsz + 1];
-                if (!got_ack && check_crc(ack, sizeof(struct BlockRequestAck))) {
+                // Not checksum-gated: this AP's ack packets don't carry a
+                // checksum this build's additive scheme validates (unlike
+                // AvailDataInfo/BlockRequest, which do) — trust size/type.
+                if (!got_ack) {
                     got_ack = true;
                     rtt_puts("ACK w=");
                     rtt_put_hex8((ack->pleaseWaitMs >> 8) & 0xFF);

--- a/firmware/oepl_radio_cc2630.h
+++ b/firmware/oepl_radio_cc2630.h
@@ -30,6 +30,15 @@
 #define BLOCK_XFER_BUFFER_SIZE  (BLOCK_DATA_SIZE + BLOCK_HEADER_SIZE)  // 4100
 #define BLOCK_REQ_PARTS_BYTES   6
 
+// Block-part RX timing, modeled on the official OEPL ZBS243 tag firmware
+// (tag_fw/syncedproto.c: performBlockRequest + blockRxLoop(295, ...)):
+// wait briefly for the ack, honor its pleaseWaitMs, then listen for parts
+// in a short window — instead of one long fixed RX window per attempt.
+#define BLOCK_ACK_WAIT_MS       400     // how long to wait for BlockRequestAck
+#define BLOCK_PART_WINDOW_MS    350     // listen window once data starts flowing
+#define BLOCK_MAX_WAIT_MS       3000    // clamp on AP-supplied pleaseWaitMs
+#define BLOCK_RX_HW_TIMEOUT_US  5000000UL  // hardware backstop, well above the above
+
 // Wakeup reasons
 #define WAKEUP_REASON_TIMED         0
 #define WAKEUP_REASON_SPLASH        0xFB


### PR DESCRIPTION
The block-download path had a fixed 15-second RX window per attempt regardless of how quickly the AP actually responded, plus a 15-attempt budget and a "wait until attempt 8" fallback for near-complete blocks. A single modest image took ~10 minutes to transfer.

### Core fix: replace the fixed window with ack/`pleaseWaitMs`-driven timing

The official OpenEPaperLink ZBS243 tag firmware uses the same wire protocol but a much tighter model: a short wait for the `BlockRequestAck`, honoring its `pleaseWaitMs`, then a short listen window for the part burst — all within a `BLOCK_TRANSFER_ATTEMPTS=5` budget. This PR ports that model as closely as the CC2630's RF core allows:

- Added a real millisecond clock (`oepl_hw_get_time_ms`, AON_RTC-backed — previously stubbed to `0`), since the old polling loop only had iteration-counted busy-waits, which can't express a real time budget.
- `oepl_radio_request_block()` now tracks a software deadline instead of a long fixed hardware RX timeout: a short ack-wait, extended by the AP's actual `pleaseWaitMs` plus a short part-burst window once the ack (or a part) arrives.
- Attempt budget dropped from 15 to 5 to match the official firmware, with the "accept 41/42 parts" fallback rescaled accordingly.

### Two bugs found live-testing against a real AP

- The ack-checksum gate rejected every real `BlockRequestAck` from this AP (its acks don't carry a checksum matching this build's additive scheme, unlike other packet types) — `pleaseWaitMs` was never honored and every attempt fell straight through to a failure.
- Checking RX status every loop iteration (instead of sparsely, like the original code) could catch a brief non-`ACTIVE` blip in the TX-to-RX turnaround and bail before any part had a chance to arrive.

### Dropped the early-bail-on-zero-parts heuristic

Live testing showed only one block failing per transfer, always a different one — genuine transient channel noise, not a structural issue. With only 5 attempts at ~1s each (versus 15s before), giving up after two unlucky zero-response tries was needlessly impatient. The official firmware has no such heuristic either.